### PR TITLE
replace 'numeric' by 'bigint' for integer type

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -70,7 +70,7 @@ def column_type(schema_property, with_length=True):
         column_type = 'character varying'
         varchar_length = LONG_VARCHAR_LENGTH
     elif 'integer' in property_type:
-        column_type = 'numeric'
+        column_type = 'bigint'
     elif 'boolean' in property_type:
         column_type = 'boolean'
 


### PR DESCRIPTION
Taps reading bigint data will be considered integer. On Redshift, numeric is default to have 18 digits only which cause a failure in certain cases.