### PR TITLE
replace 'numeric' by 'bigint' for integer input

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -70,7 +70,7 @@ def column_type(schema_property, with_length=True):
         column_type = 'character varying'
         varchar_length = LONG_VARCHAR_LENGTH
     elif 'integer' in property_type:
-        column_type = 'numeric'
+        column_type = 'bigint'
     elif 'boolean' in property_type:
         column_type = 'boolean'
 


### PR DESCRIPTION
Taps with bigint column in the source would be converted to integer. When this is converted to numeric, Redshift has a default of 18 digits only which fail for some cases with bigint.
This can be fixed simply by defaulting to a bigint instead.